### PR TITLE
Automated BREAD tests created

### DIFF
--- a/app/Http/Controllers/Api/v1/PackageController.php
+++ b/app/Http/Controllers/Api/v1/PackageController.php
@@ -2,10 +2,12 @@
 
 namespace App\Http\Controllers\Api\v1;
 
+use App\Classes\ApiResponse;
 use App\Http\Controllers\Controller;
 use App\Models\Package;
 use App\Http\Requests\v1\StorePackageRequest;
 use App\Http\Requests\v1\UpdatePackageRequest;
+use Illuminate\Support\Facades\Auth;
 
 class PackageController extends Controller
 {
@@ -14,7 +16,13 @@ class PackageController extends Controller
      */
     public function index()
     {
-        return Package::all();
+        /*return Package::all();*/
+        $message = 'Found all '. Package::count() .' packages';
+        $packages = Package::all();
+        if ($packages->count() > 0) {
+            return ApiResponse::success($packages, $message);
+        }
+        return ApiResponse::error([], 'No packages found', 404);
     }
 
     /**
@@ -22,6 +30,9 @@ class PackageController extends Controller
      */
     public function store(StorePackageRequest $request)
     {
+        if (Auth::user()->cannot('package add')) {
+            return ApiResponse::error([], "You are not authorised to add new packages.", 403);
+        }
         $package = Package::create($request->validated());
 
         return response()->json([
@@ -47,14 +58,20 @@ class PackageController extends Controller
      */
     public function update(UpdatePackageRequest $request, string $id)
     {
+        if (Auth::user()->cannot('package add')) {
+            return ApiResponse::error([], "You are not authorised to update this package.", 403);
+        }
         $package = Package::find($id);
         if (!$package) {
             return response()->json(['message' => 'Package not found'], 404);
         }
 
         $package->update($request->validated());
-        return response()->json([
-            'message' => 'Package updated successfully', 'data' => $package]);
+        return response()->json(
+            ['message' => 'Package updated successfully', 'data' => $package],
+            201
+        );
+
     }
 
     /**
@@ -62,6 +79,9 @@ class PackageController extends Controller
      */
     public function destroy(string $id)
     {
+        if (Auth::user()->cannot('package add')) {
+            return ApiResponse::error([], "You are not authorised to delete these packages", 403);
+        }
         $package = Package::find($id);
 
         if (!$package) {

--- a/app/Http/Requests/v1/UpdatePackageRequest.php
+++ b/app/Http/Requests/v1/UpdatePackageRequest.php
@@ -22,9 +22,9 @@ class UpdatePackageRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'national_code' => 'required|string|max:255',
-            'title' => 'required|string|max:255',
-            'tga_status' => 'nullable|string|max:255',
+            'national_code' => 'sometimes|string|max:255|min:3',
+            'title' => 'sometimes|string|max:255|min:3',
+            'tga_status' => 'sometimes|nullable|string|max:255|min:3',
         ];
     }
 }

--- a/database/factories/PackageFactory.php
+++ b/database/factories/PackageFactory.php
@@ -17,7 +17,9 @@ class PackageFactory extends Factory
     public function definition(): array
     {
         return [
-            //
+            'national_code' => $this->faker->unique()->regexify('[A-Z]{3}'),
+            'title' => $this->faker->jobTitle(),
+            'tga_status' => $this->faker->randomElement(['Current', 'Replaced', 'Expired']),
         ];
     }
 }

--- a/database/seeders/PermissionSeeder.php
+++ b/database/seeders/PermissionSeeder.php
@@ -21,6 +21,7 @@ class PermissionSeeder extends Seeder
 
         // TODO: Add permissions for Package, Cluster, Unit, Timetable & etc
         // Package Permissions
+        'package browse', 'package read', 'package add', 'package edit', 'package delete',
 
         // Cluster Permissions
 

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -32,6 +32,7 @@ class RoleSeeder extends Seeder
             'view own class sessions',
             'edit own profile',
             'request changes',
+            'package browse', 'package read', 'package add', 'package edit', 'package delete',
             'course browse', 'course read', 'course add', 'course edit', 'course delete',
             'timetable browse', 'timetable read', 'timetable add', 'timetable edit', 'timetable delete'
         ]);
@@ -42,14 +43,16 @@ class RoleSeeder extends Seeder
             'view own class sessions',
             'edit own profile',
             'request changes',
+            'package browse', 'package read', 'package add',
             'course browse', 'course read', 'course add',
             'timetable browse','timetable read', 'timetable add'
-            
+
         ]);
 
         $student->syncPermissions([
             'edit own profile',
             'request changes',
+            'package browse', 'package read',
             'course browse', 'course read',
             'timetable browse','timetable read'
         ]);

--- a/routes/api_v1.php
+++ b/routes/api_v1.php
@@ -51,7 +51,20 @@ Route::apiResource('users', UserController::class);
 // });
 
 /** Packages API Routes */
-Route::apiResource('packages', PackageController::class);
+//Route::apiResource('packages', PackageController::class);
+
+/** Package API Routes */
+// No Auth: browse, show.
+Route::name("api.v1.")->group(function () {
+    Route::apiResource('packages', PackageController::class)
+        ->only(['index', 'show']);
+});
+// Auth Required: store, update, destroy.
+Route::name("api.v1.")->middleware('auth:sanctum')->group(function () {
+    Route::apiResource('packages', PackageController::class)
+        ->except(['index', 'show']);
+});
+
 
 /** Courses API Routes */
 // No Auth: browse, show.
@@ -68,6 +81,13 @@ Route::name("api.v1.")->middleware('auth:sanctum')->group(function () {
 
 /** Clusters API Routes */
 Route::apiResource('clusters', ClusterController::class);
+
+/** Packages API Routes */
+/**Route::middleware('auth:sanctum')->group(function () {
+    Route::apiResource('packages', PackageController::class);
+});**/
+
+
 
 /** Units API Routes */
 Route::apiResource('units', UnitController::class);

--- a/tests/Feature/Api/V1/PackagesTest.php
+++ b/tests/Feature/Api/V1/PackagesTest.php
@@ -1,0 +1,260 @@
+<?php
+/**
+ * Testing for Packages BREAD functionality and roles/permissions authentication.
+ * - php artisan test --filter=PackagesTest
+ *
+ * Filename:        PackagesTest.php
+ * Location:        tests/Feature/Api/v1/
+ * Project:         wits-2025-s1
+ * Date Created:    25/6/2025
+ *
+ * Author:          Tadiwanashe Gukwa <20095319@tafe.wa.edu.au>
+ *
+ */
+
+namespace Api\v1;
+
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Course;
+use App\Models\User;
+use App\Models\Cluster;
+use App\Models\Unit;
+use App\Models\Package;
+
+class PackagesTest extends TestCase
+{
+    // Clears/empties the database;
+    use RefreshDatabase;
+
+    private $course, $packages, $user, $user2, $cluster, $unit;
+
+    /**
+     * Seeds the database with some initial data for testing.
+     * - Isn't a constructor so can test with an empty database.
+     * @return void
+     */
+    private function initializeTestDatabase(): void
+    {
+        $this->initializeRolesPermissions();
+
+        $this->user = User::create([
+            'given_name' => 'Mike',
+            'family_name' => 'Johnson',
+            'email' => 'mike@example.com',
+            'password' => bcrypt('Password1'),
+        ]);
+        $this->user->assignRole('Admin');
+
+        $this->user2 = User::create([
+            'given_name' => 'Adrian',
+            'family_name' => 'Gould',
+            'email' => 'adrian@example.com',
+            'password' => bcrypt('Password1'),
+        ]);
+        $this->user2->assignRole('Student');
+
+//        $this->package = Package::create([
+//            'national_code' => 'PAC123',
+//            'title' => 'Test Package',
+//            'tga_status' => 'Current',
+//        ]);
+        $this->packages = Package::factory()->count(10)->create();
+
+        $this->course = Course::factory()->create();
+
+        $this->cluster = Cluster::create([
+            'code' => 'CLUSTER',
+            'title' => 'Advanced Clustering',
+            'qualification' => 'CLU9999',
+            'state_code' => 'CLU9',
+        ]);
+
+        $this->unit = Unit::create([
+            'national_code' => 'UNIT999',
+            'title' => 'A Unit',
+            'tga_status' => 'Current',
+            'state_code' => 'UUU1',
+            'nominal_hours' => 99,
+        ]);
+
+    }
+
+    /**
+     * Initializes roles and permissions for packages.
+     * - Is called in initializeTestDatabase() for assigning roles to the test users.
+     * @return void
+     */
+    private function initializeRolesPermissions(): void {
+        // Package Permissions
+        $permissions = [
+            'package browse', 'package read', 'package add', 'package edit', 'package delete',
+        ];
+
+        foreach ($permissions as $permission) {
+            Permission::firstOrCreate(['name' => $permission]);
+        }
+
+        $superAdmin = Role::create(['name' => 'SuperAdmin']);
+        $admin = Role::create(['name' => 'Admin']);
+        $staff = Role::create(['name' => 'Staff']);
+        $student = Role::create(['name' => 'Student']);
+
+        $superAdmin->syncPermissions(Permission::all());
+
+        $admin->syncPermissions([
+            'package browse', 'package read', 'package add', 'package edit', 'package delete',
+        ]);
+
+        $staff->syncPermissions([
+            'package browse', 'package read', 'package add',
+
+        ]);
+
+        $student->syncPermissions([
+            'package browse', 'package read',
+        ]);
+    }
+
+    /**
+     * Displays a list of all packages.
+     * @return void
+     */
+    public function test_browse_packages()
+    {
+        $this->initializeTestDatabase();
+
+        $response = $this->actingAs($this->user, 'sanctum')->get('/api/v1/packages');
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+            'success' => true,
+            'message' => 'Found all '. Package::count() .' packages',
+        ]);
+        $response->assertJsonStructure([
+            'data' => [["id", "national_code", "title", "tga_status", "created_at", "updated_at"]],
+        ]);
+    }
+
+    /**
+     * Display a package's details.
+     * @param  int  $id
+     * @return void
+     */
+    public function test_show_package(int $id = 1)
+    {
+        $this->initializeTestDatabase();
+
+        $response = $this->actingAs($this->user, 'sanctum')->get('/api/v1/packages/'.$id);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+           /* 'success' => true,*/
+            'message' => 'Package Found',
+        ]);
+        $response->assertJsonStructure([
+            'data' => ["id", "national_code", "title", "tga_status", "created_at", "updated_at"]
+        ]);
+
+    }
+
+    /**
+     * Create a new Package & store it in the database.
+     * @return void
+     */
+    public function test_store_package()
+    {
+        $this->initializeTestDatabase();
+
+        $newPackage = [
+
+            'national_code' => "g432" ,
+            'title' => "datascience",
+            'tga_status' => "current",
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')->post('/api/v1/packages/', $newPackage);
+        $response->assertStatus(201);
+        $response->assertJsonFragment([
+
+            'message' => 'Package created',
+        ]);
+        $response->assertJsonStructure([
+            'data' => ["id", "national_code", "title", "tga_status", "created_at", "updated_at"],
+        ]);
+    }
+
+    /**
+     * Update the specified Package in the database.
+     * @return void
+     */
+    public function test_update_package()
+    {
+        $this->initializeTestDatabase();
+
+        $updatePackage = Package::latest()->first();
+
+        $newPackage = [
+            "national_code" => "NOT00000",
+            "title" => "Not Testing",
+            "cluster_id" => [1],
+            "unit_id" => [1],
+        ];
+
+        $response = $this->actingAs($this->user, 'sanctum')->patch('/api/v1/packages/'.$updatePackage->id, $newPackage);
+
+        $response->assertStatus(201);
+        $response->assertJsonFragment([
+
+            'message' => 'Package updated successfully',
+        ]);
+        $response->assertJsonStructure([
+            'data' => ["id", "national_code", "title", "tga_status", "created_at", "updated_at"],
+        ]);
+
+    }
+
+    /**
+     * Remove a Pckage from the database.
+     * @return void
+     */
+    public function test_destroy_package()
+    {
+        $this->initializeTestDatabase();
+
+        $package = Package::first();
+
+        $response = $this->actingAs($this->user, 'sanctum')->delete('/api/v1/packages/'.$package->id);
+
+        $response->assertStatus(200);
+        $response->assertJsonFragment([
+
+        ]);
+        $response->assertJsonStructure([
+            'data' => [],
+        ]);
+        $this->assertDatabaseMissing('packages', ['id' => $package->id]);
+    }
+
+    /**
+     * Stops user without the correct permissions from removing a package from the database.
+     * @return void
+     */
+    public function test_package_permissions()
+    {
+        $this->initializeTestDatabase();
+
+        $package = Package::first();
+
+        $response = $this->actingAs($this->user2, 'sanctum')->delete('/api/v1/packages/'.$package->id);
+
+        $response->assertStatus(403);
+        $response->assertJsonFragment([
+
+            'message' => "You are not authorised to delete these packages",
+        ]);
+        $this->assertDatabaseHas('packages', ['id' => $package->id]);
+    }
+}


### PR DESCRIPTION
## Summary by Sourcery

Introduce structured API responses with authorization checks, refine routing and validation, seed package permissions, and add automated BREAD tests for the Package resource.

Enhancements:
- Standardize Package endpoints to use ApiResponse for success and error responses with appropriate HTTP status codes.
- Add authorization checks on package creation, update, and deletion based on user permissions.
- Restructure API routes to separate public (index, show) and authenticated (store, update, destroy) access via sanctum middleware.
- Update UpdatePackageRequest to apply 'sometimes' and min-length validation for fields.
- Enhance PackageFactory to generate realistic national_code, title, and tga_status attributes.

Tests:
- Add PackagesTest with full CRUD and permission enforcement coverage for the Package API.

Chores:
- Seed 'package' permissions in RoleSeeder and PermissionSeeder.