### PR TITLE
feat PackageController authentication feature changes

### DIFF
--- a/app/Http/Controllers/Api/v1/PackageController.php
+++ b/app/Http/Controllers/Api/v1/PackageController.php
@@ -58,7 +58,7 @@ class PackageController extends Controller
      */
     public function update(UpdatePackageRequest $request, string $id)
     {
-        if (Auth::user()->cannot('package add')) {
+        if (Auth::user()->cannot('package edit')) {
             return ApiResponse::error([], "You are not authorised to update this package.", 403);
         }
         $package = Package::find($id);
@@ -79,7 +79,7 @@ class PackageController extends Controller
      */
     public function destroy(string $id)
     {
-        if (Auth::user()->cannot('package add')) {
+        if (Auth::user()->cannot('package delete')) {
             return ApiResponse::error([], "You are not authorised to delete these packages", 403);
         }
         $package = Package::find($id);

--- a/tests/Feature/Api/V1/PackagesTest.php
+++ b/tests/Feature/Api/V1/PackagesTest.php
@@ -31,12 +31,9 @@ class PackagesTest extends TestCase
 
     private $course, $packages, $user, $user2, $cluster, $unit;
 
-    /**
-     * Seeds the database with some initial data for testing.
-     * - Isn't a constructor so can test with an empty database.
-     * @return void
-     */
     private function initializeTestDatabase(): void
+
+
     {
         $this->initializeRolesPermissions();
 
@@ -82,11 +79,7 @@ class PackagesTest extends TestCase
 
     }
 
-    /**
-     * Initializes roles and permissions for packages.
-     * - Is called in initializeTestDatabase() for assigning roles to the test users.
-     * @return void
-     */
+
     private function initializeRolesPermissions(): void {
         // Package Permissions
         $permissions = [


### PR DESCRIPTION
## Summary by Sourcery

Fix incorrect authorization checks in PackageController and clean up redundant test docblocks

Bug Fixes:
- Change update permission check to use 'package edit' instead of 'package add'
- Change destroy permission check to use 'package delete' instead of 'package add'

Chores:
- Remove redundant docblocks from initializeTestDatabase() and initializeRolesPermissions() methods in PackagesTest