### PR TITLE
bug-fix: remove duplicated user route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -39,7 +39,7 @@ Route::get('/dashboard', function () {
 
 Route::resource('units', UnitController::class);
 
-// Route::resource('users', UserController::class);
+
 Route::resource('clusters', ClusterController::class);
 
 Route::get('/clusters', [ClusterController::class, 'index'])->name('clusters.index');


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Eliminate redundant Route::resource('users') and related individual user routes in web.php, leaving only one resource declaration.